### PR TITLE
Seastone2 api psu get power

### DIFF
--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/__init__.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["platform", "chassis"]
+from sonic_platform import *

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/chassis.py
@@ -21,6 +21,7 @@ class Chassis(ChassisBase):
     """Platform-specific Chassis class"""
 
     FAN_CONFIG = 'fan.json'
+    PSU_CONFIG = 'psu.json'
 
     def __init__(self):
         ChassisBase.__init__(self)
@@ -28,6 +29,7 @@ class Chassis(ChassisBase):
         self._api_config = self._api_common.get_config_path()
 
         self.__initialize_fan()
+        self.__initialize_psu()
 
         # self.is_host = self._api_common.is_host()
 
@@ -59,11 +61,18 @@ class Chassis(ChassisBase):
     #         self._sfp_list.append(sfp)
     #     self.sfp_module_initialized = True
 
-    # def __initialize_psu(self):
-    #     from sonic_platform.psu import Psu
-    #     for index in range(0, NUM_PSU):
-    #         psu = Psu(index)
-    #         self._psu_list.append(psu)
+    def __initialize_psu(self):
+        from sonic_platform.psu import Psu
+
+        psu_config_path = os.path.join(self._api_config, self.PSU_CONFIG)
+        psu_config = self._api_common.load_json_file(psu_config_path)
+        
+        if psu_config:
+            psu_index = 0
+            for index in range(0, psu_config['psu_num']):
+                psu = Psu(psu_index, conf=psu_config)
+                psu_index += 1
+                self._psu_list.append(psu)
 
     # def __initialize_thermals(self):
     #     from sonic_platform.thermal import Thermal

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/chassis.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python
+
+#############################################################################
+# Celestica
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the Chassis information which are available in the platform
+#
+#############################################################################
+
+try:
+    import sys
+    import os
+    from sonic_platform_base.chassis_base import ChassisBase
+    from common import Common
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Chassis(ChassisBase):
+    """Platform-specific Chassis class"""
+
+    FAN_CONFIG = 'fan.json'
+
+    def __init__(self):
+        ChassisBase.__init__(self)
+        self._api_common = Common()
+        self._api_config = self._api_common.get_config_path()
+
+        self.__initialize_fan()
+
+        # self.is_host = self._api_common.is_host()
+
+        # if not self.is_host:
+        #     self.__initialize_fan()
+        #     self.__initialize_psu()
+        #     self.__initialize_thermals()
+        # else:
+        #     self.__initialize_components()
+
+    def __initialize_fan(self):
+        from sonic_platform.fan import Fan
+
+        fan_config_path = os.path.join(self._api_config, self.FAN_CONFIG)
+        fan_config = self._api_common.load_json_file(fan_config_path)
+
+        if fan_config:
+            fan_index = 0
+            for drawer_index in range(0, fan_config['drawer_num']):
+                for index in range(0, fan_config['fan_num_per_drawer']):
+                    fan = Fan(fan_index, drawer_index, conf=fan_config)
+                    fan_index += 1
+                    self._fan_list.append(fan)
+
+    # def __initialize_sfp(self):
+    #     from sonic_platform.sfp import Sfp
+    #     for index in range(0, NUM_SFP):
+    #         sfp = Sfp(index)
+    #         self._sfp_list.append(sfp)
+    #     self.sfp_module_initialized = True
+
+    # def __initialize_psu(self):
+    #     from sonic_platform.psu import Psu
+    #     for index in range(0, NUM_PSU):
+    #         psu = Psu(index)
+    #         self._psu_list.append(psu)
+
+    # def __initialize_thermals(self):
+    #     from sonic_platform.thermal import Thermal
+    #     for index in range(0, NUM_THERMAL):
+    #         thermal = Thermal(index)
+    #         self._thermal_list.append(thermal)
+
+    # def __initialize_eeprom(self):
+    #     from sonic_platform.eeprom import Tlv
+    #     self._eeprom = Tlv()
+
+    # def __initialize_components(self):
+    #     from sonic_platform.component import Component
+    #     for index in range(0, NUM_COMPONENT):
+    #         component = Component(index)
+    #         self._component_list.append(component)
+
+    # def get_base_mac(self):
+    #     """
+    #     Retrieves the base MAC address for the chassis
+    #     Returns:
+    #         A string containing the MAC address in the format
+    #         'XX:XX:XX:XX:XX:XX'
+    #     """
+    #     return self._eeprom.get_mac()
+
+    # def get_serial_number(self):
+    #     """
+    #     Retrieves the hardware serial number for the chassis
+    #     Returns:
+    #         A string containing the hardware serial number for this chassis.
+    #     """
+    #     return self._eeprom.get_serial()
+
+    # def get_system_eeprom_info(self):
+    #     """
+    #     Retrieves the full content of system EEPROM information for the chassis
+    #     Returns:
+    #         A dictionary where keys are the type code defined in
+    #         OCP ONIE TlvInfo EEPROM format and values are their corresponding
+    #         values.
+    #     """
+    #     return self._eeprom.get_eeprom()
+
+    # def get_reboot_cause(self):
+    #     """
+    #     Retrieves the cause of the previous reboot
+    #     Returns:
+    #         A tuple (string, string) where the first element is a string
+    #         containing the cause of the previous reboot. This string must be
+    #         one of the predefined strings in this class. If the first string
+    #         is "REBOOT_CAUSE_HARDWARE_OTHER", the second string can be used
+    #         to pass a description of the reboot cause.
+    #     """
+    #     description = 'None'
+    #     reboot_cause = self.REBOOT_CAUSE_HARDWARE_OTHER
+
+    #     reboot_cause_path = (
+    #         HOST_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE) if self.is_host else PMON_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE
+    #     prev_reboot_cause_path = (
+    #         HOST_REBOOT_CAUSE_PATH + PREV_REBOOT_CAUSE_FILE) if self.is_host else PMON_REBOOT_CAUSE_PATH + PREV_REBOOT_CAUSE_FILE
+
+    #     hw_reboot_cause = self._component_list[0].get_register_value(
+    #         RESET_REGISTER)
+
+    #     sw_reboot_cause = self._api_common.read_txt_file(
+    #         reboot_cause_path) or "Unknown"
+    #     prev_sw_reboot_cause = self._api_common.read_txt_file(
+    #         prev_reboot_cause_path) or "Unknown"
+
+    #     if sw_reboot_cause == "Unknown" and (prev_sw_reboot_cause == "Unknown" or prev_sw_reboot_cause == self.REBOOT_CAUSE_POWER_LOSS) and hw_reboot_cause == "0x11":
+    #         reboot_cause = self.REBOOT_CAUSE_POWER_LOSS
+    #     elif sw_reboot_cause != "Unknown" and hw_reboot_cause == "0x11":
+    #         reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
+    #         description = sw_reboot_cause
+    #     elif prev_reboot_cause_path != "Unknown" and hw_reboot_cause == "0x11":
+    #         reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
+    #         description = prev_sw_reboot_cause
+    #     elif hw_reboot_cause == "0x22":
+    #         reboot_cause = self.REBOOT_CAUSE_WATCHDOG,
+    #     else:
+    #         reboot_cause = self.REBOOT_CAUSE_HARDWARE_OTHER
+    #         description = 'Unknown reason'
+
+    #     return (reboot_cause, description)
+
+    # ##############################################################
+    # ######################## SFP methods #########################
+    # ##############################################################
+
+    # def get_num_sfps(self):
+    #     """
+    #     Retrieves the number of sfps available on this chassis
+    #     Returns:
+    #         An integer, the number of sfps available on this chassis
+    #     """
+    #     if not self.sfp_module_initialized:
+    #         self.__initialize_sfp()
+
+    #     return len(self._sfp_list)
+
+    # def get_all_sfps(self):
+    #     """
+    #     Retrieves all sfps available on this chassis
+    #     Returns:
+    #         A list of objects derived from SfpBase representing all sfps
+    #         available on this chassis
+    #     """
+    #     if not self.sfp_module_initialized:
+    #         self.__initialize_sfp()
+
+    #     return self._sfp_list
+
+    # def get_sfp(self, index):
+    #     """
+    #     Retrieves sfp represented by (1-based) index <index>
+    #     Args:
+    #         index: An integer, the index (1-based) of the sfp to retrieve.
+    #         The index should be the sequence of a physical port in a chassis,
+    #         starting from 1.
+    #         For example, 1 for Ethernet0, 2 for Ethernet4 and so on.
+    #     Returns:
+    #         An object dervied from SfpBase representing the specified sfp
+    #     """
+    #     sfp = None
+    #     if not self.sfp_module_initialized:
+    #         self.__initialize_sfp()
+
+    #     try:
+    #         # The index will start from 1
+    #         sfp = self._sfp_list[index-1]
+    #     except IndexError:
+    #         sys.stderr.write("SFP index {} out of range (1-{})\n".format(
+    #                          index, len(self._sfp_list)))
+    #     return sfp
+
+    # ##############################################################
+    # ####################### Other methods ########################
+    # ##############################################################
+
+    # def get_watchdog(self):
+    #     """
+    #     Retreives hardware watchdog device on this chassis
+    #     Returns:
+    #         An object derived from WatchdogBase representing the hardware
+    #         watchdog device
+    #     """
+    #     if self._watchdog is None:
+    #         from sonic_platform.watchdog import Watchdog
+    #         self._watchdog = Watchdog()
+
+    #     return self._watchdog
+
+    # ##############################################################
+    # ###################### Device methods ########################
+    # ##############################################################
+
+    # def get_name(self):
+    #     """
+    #     Retrieves the name of the device
+    #         Returns:
+    #         string: The name of the device
+    #     """
+    #     return self._api_common.hwsku
+
+    # def get_presence(self):
+    #     """
+    #     Retrieves the presence of the PSU
+    #     Returns:
+    #         bool: True if PSU is present, False if not
+    #     """
+    #     return True
+
+    # def get_model(self):
+    #     """
+    #     Retrieves the model number (or part number) of the device
+    #     Returns:
+    #         string: Model/part number of device
+    #     """
+    #     return self._eeprom.get_pn()
+
+    # def get_serial(self):
+    #     """
+    #     Retrieves the serial number of the device
+    #     Returns:
+    #         string: Serial number of device
+    #     """
+    #     return self.get_serial_number()
+
+    # def get_status(self):
+    #     """
+    #     Retrieves the operational status of the device
+    #     Returns:
+    #         A boolean value, True if device is operating properly, False if not
+    #     """
+    #     return True

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/common.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/common.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+
+import os
+import json
+import struct
+import subprocess
+from sonic_daemon_base.daemon_base import DaemonBase
+from mmap import *
+
+# HOST_CHK_CMD = "docker > /dev/null 2>&1"
+# EMPTY_STRING = ""
+
+CONFIG_PATH = '/usr/share/sonic/device/{}/sonic_platform_config'
+
+class Common:
+
+    NULL_VAL = 'N/A'
+
+    OPER_IMPI = 'ipmi'
+    OPER_FIXED_LIST = 'fixed_list'
+    OPER_FIXED = 'fixed'
+
+    def __init__(self):
+        (self.platform, self.hwsku) = DaemonBase().get_platform_and_hwsku()
+
+    def get_config_path(self):
+        return CONFIG_PATH.format(self.platform)
+
+    def load_json_file(self, path):
+        json_data = {}
+        try:
+            json_data = json.load(open(path))
+        except IOError:
+            pass
+        return json_data
+
+    def run_command(self, cmd):
+        status = True
+        result = ""
+        try:
+            p = subprocess.Popen(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            raw_data, err = p.communicate()
+            if err == '':
+                result = raw_data.strip()
+        except Exception as e:
+            print(e)
+            status = False
+        return status, result
+
+    # def is_host(self):
+    #     return os.system(HOST_CHK_CMD) == 0
+
+    # def pci_get_value(self, resource, offset):
+    #     status = True
+    #     result = ""
+    #     try:
+    #         fd = os.open(resource, os.O_RDWR)
+    #         mm = mmap(fd, 0)
+    #         mm.seek(int(offset))
+    #         read_data_stream = mm.read(4)
+    #         result = struct.unpack('I', read_data_stream)
+    #     except:
+    #         status = False
+    #     return status, result
+
+
+
+    # def run_interactive_command(self, cmd):
+    #     try:
+    #         os.system(cmd)
+    #     except:
+    #         return False
+    #     return True
+
+    # def read_txt_file(self, file_path):
+    #     try:
+    #         with open(file_path, 'r') as fd:
+    #             data = fd.read()
+    #             return data.strip()
+    #     except IOError:
+    #         pass
+    #     return None
+
+    # def read_one_line_file(self, file_path):
+    #     try:
+    #         with open(file_path, 'r') as fd:
+    #             data = fd.readline()
+    #             return data.strip()
+    #     except IOError:
+    #         pass
+    #     return None
+
+    # def ipmi_raw(self, netfn, cmd):
+    #     status = True
+    #     result = ""
+    #     try:
+    #         cmd = "ipmitool raw {} {}".format(str(netfn), str(cmd))
+    #         p = subprocess.Popen(
+    #             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    #         raw_data, err = p.communicate()
+    #         if err == '':
+    #             result = raw_data.strip()
+    #         else:
+    #             status = False
+    #     except:
+    #         status = False
+    #     return status, result
+
+    # def ipmi_fru_id(self, id, key=None):
+    #     status = True
+    #     result = ""
+    #     try:
+    #         cmd = "ipmitool fru print {}".format(str(
+    #             id)) if not key else "ipmitool fru print {0} | grep '{1}' ".format(str(id), str(key))
+
+    #         p = subprocess.Popen(
+    #             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    #         raw_data, err = p.communicate()
+    #         if err == '':
+    #             result = raw_data.strip()
+    #         else:
+    #             status = False
+    #     except:
+    #         status = False
+    #     return status, result
+
+    # def ipmi_set_ss_thres(self, id, threshold_key, value):
+    #     status = True
+    #     result = ""
+    #     try:
+    #         cmd = "ipmitool sensor thresh '{}' {} {}".format(
+    #             str(id), str(threshold_key), str(value))
+    #         p = subprocess.Popen(
+    #             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    #         raw_data, err = p.communicate()
+    #         if err == '':
+    #             result = raw_data.strip()
+    #         else:
+    #             status = False
+    #     except:
+    #         status = False
+    #     return status, result

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/common.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/common.py
@@ -77,6 +77,8 @@ class Common:
         if config.get('output_transform'):
             ret_val = config['output_transform'].get(
                 result, config['default_output'])
+        elif config.get('output_formula'):
+            ret_val = eval(config['output_formula'][index].format(result))
         else:
             ret_val = eval(config['formula'].format(result))
         return status, ret_val

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/fan.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/fan.py
@@ -156,6 +156,34 @@ class Fan(FanBase):
 
     #     return False
 
+    def get_status_led(self):
+        """
+        Gets the state of the fan status LED
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings above
+
+        Note:
+            STATUS_LED_COLOR_GREEN = "green"
+            STATUS_LED_COLOR_AMBER = "amber"
+            STATUS_LED_COLOR_RED = "red"
+            STATUS_LED_COLOR_OFF = "off"
+        """
+
+        status_led = self.STATUS_LED_COLOR_OFF
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+
+        if self.is_psu_fan:
+            # Not support
+            return self.STATUS_LED_COLOR_OFF
+        elif self.get_presence():
+            if config.get('oper_type') == Common.OPER_IMPI:
+                full_cmd = config['template'].format(config['command'][self.fan_index])
+                status, result = self._api_common.run_command(full_cmd)
+                status_led = eval(config['formula'].format(result))
+
+        return status_led
+
     # def set_status_led(self, color):
     #     """
     #     Sets the state of the fan module status LED

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/fan.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/fan.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+
+#############################################################################
+# Celestica
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the fan status which are available in the platform
+#
+#############################################################################
+
+import json
+import math
+import os.path
+import inspect
+
+try:
+    from sonic_platform_base.fan_base import FanBase
+    from common import Common
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Fan(FanBase):
+    """Platform-specific Fan class"""
+
+    def __init__(self, index, drawer_index, is_psu_fan=False, psu_index=0, conf=None):
+        FanBase.__init__(self)
+
+        self.fan_index = index
+        self.drawer_index = drawer_index
+
+        self._config = conf
+        self._api_common = Common()
+        self._name = self.get_name()
+        self._is_psu_fan = is_psu_fan
+
+        # self.is_psu_fan = is_psu_fan
+        # if self.is_psu_fan:
+        #     self.psu_index = psu_index
+        #     self.psu_i2c_num = PSU_I2C_MAPPING[self.psu_index]["num"]
+        #     self.psu_i2c_addr = PSU_I2C_MAPPING[self.psu_index]["addr"]
+        #     self.psu_hwmon_path = PSU_HWMON_PATH.format(
+        #         self.psu_i2c_num, self.psu_i2c_addr)
+
+    def get_direction(self):
+        """
+        Retrieves the direction of fan
+        Returns:
+            A string, either FAN_DIRECTION_INTAKE or FAN_DIRECTION_EXHAUST
+            depending on fan direction
+        """
+        direction = self.FAN_DIRECTION_NOT_APPLICABLE
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+
+        if self.get_presence() and config.get('oper_type') == Common.OPER_IMPI:
+            cmd = config['command'][self.fan_index]
+            full_cmd = config['template'].format(
+                config['command'][self.fan_index])
+            status, result = self._api_common.run_command(full_cmd)
+            direction = eval(config['formula'].format(
+                result)) if status else direction
+
+        return direction
+
+    def get_speed(self):
+        """
+        Retrieves the speed of fan as a percentage of full speed
+        Returns:
+            An integer, the percentage of full fan speed, in the range 0 (off)
+                 to 100 (full speed)
+
+        Note:
+            speed = pwm_in/255*100
+        """
+        speed = 0
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+
+        if self._is_psu_fan:
+            pass
+        elif self.get_presence():
+            if config.get('oper_type') == Common.OPER_IMPI:
+                max_rpm = config['max_rear'] if 'R' in self._name else config['max_front']
+                cmd = config['command'][self.fan_index]
+                full_cmd = config['template'].format(
+                    config['command'][self.fan_index])
+                status, result = self._api_common.run_command(full_cmd)
+                speed_raw = eval(config['formula'].format(
+                    result)) if status else speed
+                speed = float(speed_raw) / max_rpm * 100.0
+
+        return int(speed)
+
+    def get_target_speed(self):
+        """
+        Retrieves the target (expected) speed of the fan
+        Returns:
+            An integer, the percentage of full fan speed, in the range 0 (off)
+                 to 100 (full speed)
+
+        Note:
+            0   : when PWM mode is not in use
+            pwm : when pwm mode is not use
+        """
+        target_speed = Common.NULL_VAL
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+
+        if config.get('oper_type') == Common.OPER_FIXED:
+            target_speed = config["value"]
+
+        return target_speed
+
+    def get_speed_tolerance(self):
+        """
+        Retrieves the speed tolerance of the fan
+        Returns:
+            An integer, the percentage of variance from target speed which is
+                 considered tolerable
+        """
+        speed_tolerance = Common.NULL_VAL
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+
+        if config.get('oper_type') == Common.OPER_FIXED:
+            speed_tolerance = config["value"]
+
+        return speed_tolerance
+
+    # def set_speed(self, speed):
+    #     """
+    #     Sets the fan speed
+    #     Args:
+    #         speed: An integer, the percentage of full fan speed to set fan to,
+    #                in the range 0 (off) to 100 (full speed)
+    #     Returns:
+    #         A boolean, True if speed is set successfully, False if not
+
+    #     Note:
+    #         Depends on pwm or target mode is selected:
+    #         1) pwm = speed_pc * 255             <-- Currently use this mode.
+    #         2) target_pwm = speed_pc * 100 / 255
+    #          2.1) set pwm{}_enable to 3
+
+    #     """
+    #     pwm = speed * 255 / 100
+    #     if not self.is_psu_fan and self.get_presence():
+    #         chip = self.emc2305_chip_mapping[self.fan_index]
+    #         device = chip['device']
+    #         fan_index = chip['index_map']
+    #         sysfs_path = "%s%s/%s" % (
+    #             EMC2305_PATH, device, EMC2305_FAN_PWM)
+    #         sysfs_path = sysfs_path.format(fan_index[self.drawer_index])
+    #         return self.__write_txt_file(sysfs_path, int(pwm))
+
+    #     return False
+
+    # def set_status_led(self, color):
+    #     """
+    #     Sets the state of the fan module status LED
+    #     Args:
+    #         color: A string representing the color with which to set the
+    #                fan module status LED
+    #     Returns:
+    #         bool: True if status LED state is set successfully, False if not
+    #     """
+    #     set_status_led = False
+    #     if not self.is_psu_fan:
+    #         s1, s2 = False, False
+    #         try:
+    #             if color == self.STATUS_LED_COLOR_GREEN:
+    #                 s1 = self.__set_gpio_value(
+    #                     self.dx010_fan_gpio[self.drawer_index+1]['color']['red'], 1)
+    #                 s2 = self.__set_gpio_value(
+    #                     self.dx010_fan_gpio[self.drawer_index+1]['color']['green'], 0)
+
+    #             elif color == self.STATUS_LED_COLOR_RED:
+    #                 s1 = self.__set_gpio_value(
+    #                     self.dx010_fan_gpio[self.drawer_index+1]['color']['red'], 0)
+    #                 s2 = self.__set_gpio_value(
+    #                     self.dx010_fan_gpio[self.drawer_index+1]['color']['green'], 1)
+
+    #             elif color == self.STATUS_LED_COLOR_OFF:
+    #                 s1 = self.__set_gpio_value(
+    #                     self.dx010_fan_gpio[self.drawer_index+1]['color']['red'], 1)
+    #                 s2 = self.__set_gpio_value(
+    #                     self.dx010_fan_gpio[self.drawer_index+1]['color']['green'], 1)
+    #             set_status_led = s1 and s2
+    #             return set_status_led
+    #         except IOError:
+    #             return False
+
+    #     return set_status_led
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """
+        name = Common.NULL_VAL
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+
+        if config.get('oper_type') == Common.OPER_FIXED_LIST:
+            name = config["value"][self.fan_index]
+
+        return name
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the FAN
+        Returns:
+            bool: True if FAN is present, False if not
+        """
+        present = False
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+
+        if config.get('oper_type') == Common.OPER_IMPI:
+            cmd = config['command'][self.fan_index]
+            full_cmd = config['template'].format(
+                config['command'][self.fan_index])
+            status, result = self._api_common.run_command(full_cmd)
+            present = eval(config['formula'].format(
+                result)) if status else present
+
+        return present
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+        model = Common.NULL_VAL
+
+        if self.get_presence() and config.get('oper_type') == Common.OPER_IMPI:
+            cmd = config['command'][self.fan_index]
+            full_cmd = config['template'].format(
+                config['command'][self.fan_index])
+            status, result = self._api_common.run_command(full_cmd)
+            model = eval(config['formula'].format(
+                result)) if status else model
+
+        return model
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        # if self.is_psu_fan:
+        #     return NULL_VAL
+
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+        serial = Common.NULL_VAL
+
+        if self.get_presence() and config.get('oper_type') == Common.OPER_IMPI:
+            cmd = config['command'][self.fan_index]
+            full_cmd = config['template'].format(
+                config['command'][self.fan_index])
+            status, result = self._api_common.run_command(full_cmd)
+            serial = eval(config['formula'].format(
+                result)) if status else serial
+
+        return serial
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the device
+        Returns:
+            A boolean value, True if device is operating properly, False if not
+        """
+        return self.get_presence() and self.get_speed() > 10

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/platform.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/platform.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#############################################################################
+# Celestica
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the platform information
+#
+#############################################################################
+
+try:
+    from sonic_platform_base.platform_base import PlatformBase
+    from sonic_platform.chassis import Chassis
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Platform(PlatformBase):
+    """Platform-specific Platform class"""
+
+    def __init__(self):
+        PlatformBase.__init__(self)
+        self._chassis = Chassis()

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/psu.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/psu.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+
+#############################################################################
+# Celestica
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the fan status which are available in the platform
+#
+#############################################################################
+
+import json
+import math
+import os.path
+import inspect
+
+try:
+    from sonic_platform_base.psu_base import PsuBase
+    from common import Common
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Psu(PsuBase):
+    """Platform-specific Fan class"""
+
+    def __init__(self, index, psu_index=0, conf=None):
+        PsuBase.__init__(self)
+
+        self.psu_index = index
+
+        self._config = conf
+        self._api_common = Common()
+        self._name = self.get_name()
+        #self._is_psu_fan = is_psu_fan
+
+        # self._is_psu_fan = is_psu_fan
+        # if self._is_psu_fan:
+        #     self.psu_index = psu_index
+        #     self.psu_i2c_num = PSU_I2C_MAPPING[self.psu_index]["num"]
+        #     self.psu_i2c_addr = PSU_I2C_MAPPING[self.psu_index]["addr"]
+        #     self.psu_hwmon_path = PSU_HWMON_PATH.format(
+        #         self.psu_i2c_num, self.psu_i2c_addr)
+
+    def get_num_fans(self):
+        """
+        Retrieves the number of fan modules available on this PSU
+
+        Returns:
+            An integer, the number of fan modules available on this PSU
+        """
+        default = Common.NULL_VAL
+        f_name = inspect.stack()[0][3]
+        config = self._config.get("get_name")
+
+        psu_attr = self._api_common.get_val(self.psu_index, config, default)
+        
+        __fan_list = psu_attr['fan_name']
+
+        return len(self._fan_list) if self.get_presence() else default
+
+    def get_all_fans(self):
+        """
+        Retrieves all fan modules available on this PSU
+
+        Returns:
+            A list of objects derived from FanBase representing all fan
+            modules available on this PSU
+        """
+        default = Common.NULL_VAL
+        f_name = inspect.stack()[0][3]
+        config = self._config.get("get_name")
+
+        psu_attr = self._api_common.get_val(self.psu_index, config, default)
+        
+        __fan_list = psu_attr['fan_name']
+
+        return self._fan_list if self.get_presence() else default
+
+    def get_fan(self, index):
+        """
+        Retrieves fan module represented by (0-based) index <index>
+
+        Args:
+            index: An integer, the index (0-based) of the fan module to
+            retrieve
+
+        Returns:
+            An object dervied from FanBase representing the specified fan
+            module
+        """
+        fan = None
+
+        try:
+            fan = self._fan_list[index]
+        except IndexError:
+            sys.stderr.write("Fan index {} out of range (0-{})\n".format(
+                             index, len(self._fan_list)-1))
+
+        return fan
+
+    def get_voltage(self):
+        """
+        Retrieves current PSU voltage output
+
+        Returns:
+            A float number, the output voltage in volts, 
+            e.g. 12.1 
+        """
+        raise NotImplementedError
+
+    def get_current(self):
+        """
+        Retrieves present electric current supplied by PSU
+
+        Returns:
+            A float number, the electric current in amperes, e.g 15.4
+        """
+        raise NotImplementedError
+
+    def get_power(self):
+        """
+        Retrieves current energy supplied by PSU
+
+        Returns:
+            A float number, the power in watts, e.g. 302.6
+        """
+        
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+        ret_val = 0
+
+        if self.get_presence() and config.get('oper_type') == Common.OPER_IMPI:
+            status, result = self._api_common.ipmi_get(self.psu_index, config)
+            raw_val = result if status else ret_val
+
+        return float(raw_val)
+
+    def get_powergood_status(self):
+        """
+        Retrieves the powergood status of PSU
+
+        Returns:
+            A boolean, True if PSU has stablized its output voltages and passed all
+            its internal self-tests, False if not.
+        """
+        raise NotImplementedError
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the PSU status LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   PSU status LED
+
+        Returns:
+            bool: True if status LED state is set successfully, False if not
+        """
+        raise NotImplementedError
+
+    def get_status_led(self):
+        """
+        Gets the state of the PSU status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings above
+        """
+        raise NotImplementedError
+
+    def get_temperature(self):
+        """
+        Retrieves current temperature reading from PSU
+
+        Returns:
+            A float number of current temperature in Celsius up to nearest thousandth
+            of one degree Celsius, e.g. 30.125 
+        """
+        raise NotImplementedError
+
+    def get_temperature_high_threshold(self):
+        """
+        Retrieves the high threshold temperature of PSU
+
+        Returns:
+            A float number, the high threshold temperature of PSU in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        raise NotImplementedError
+
+    def get_voltage_high_threshold(self):
+        """
+        Retrieves the high threshold PSU voltage output
+
+        Returns:
+            A float number, the high threshold output voltage in volts, 
+            e.g. 12.1 
+        """
+        raise NotImplementedError
+
+    def get_voltage_low_threshold(self):
+        """
+        Retrieves the low threshold PSU voltage output
+
+        Returns:
+            A float number, the low threshold output voltage in volts, 
+            e.g. 12.1 
+        """
+        raise NotImplementedError
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """
+        default = Common.NULL_VAL
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+
+        psu_attr = self._api_common.get_val(self.psu_index, config, default)
+        
+        psu_name = psu_attr['psu_name']
+
+        return psu_name if self.get_presence() else default
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the PSU
+        Returns:
+            bool: True if PSU is present, False if not
+        """
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+        ret_val = False
+
+        if config.get('oper_type') == Common.OPER_IMPI:
+            status, result = self._api_common.ipmi_get(self.psu_index, config)
+            ret_val = result if status else ret_val
+
+        return ret_val

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/fan.json
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/fan.json
@@ -1,0 +1,125 @@
+{
+        "fan_num_per_drawer": 2,
+        "drawer_num": 4,
+        "get_name": {
+                "oper_type": "fixed_list",
+                "value": [
+                        "Fan1-F",
+                        "Fan1-R",
+                        "Fan2-F",
+                        "Fan2-R",
+                        "Fan3-F",
+                        "Fan3-R",
+                        "Fan4-F",
+                        "Fan4-R"
+                ]
+        },
+        "get_presence": {
+                "oper_type": "ipmi",
+                "template": "ipmitool raw 0x3a 0x03 0x03 {}",
+                "command": [
+                        "0x00",
+                        "0x00",
+                        "0x01",
+                        "0x01",
+                        "0x02",
+                        "0x02",
+                        "0x03",
+                        "0x03"
+                ],
+                "formula": "True if '00' in '{}' else False"
+        },
+        "get_model": {
+                "oper_type": "ipmi",
+                "template": "ipmitool fru list {} | grep 'Board Part Number'",
+                "command": [
+                        "5",
+                        "5",
+                        "6",
+                        "6",
+                        "7",
+                        "7",
+                        "8",
+                        "8"
+                ],
+                "formula": "'{}'.split()[-1]"
+        },
+        "get_serial": {
+                "oper_type": "ipmi",
+                "template": "ipmitool fru list {} | grep 'Board Serial'",
+                "command": [
+                        "5",
+                        "5",
+                        "6",
+                        "6",
+                        "7",
+                        "7",
+                        "8",
+                        "8"
+                ],
+                "formula": "'{}'.split()[-1]"
+        },
+        "get_status": {},
+        "get_direction": {
+                "oper_type": "ipmi",
+                "template": "ipmitool fru list {} | grep 'F2B\\|B2F'",
+                "command": [
+                        "5",
+                        "5",
+                        "6",
+                        "6",
+                        "7",
+                        "7",
+                        "8",
+                        "8"
+                ],
+                "formula": "'intake' if 'B2F' in '{}' else 'exhaust'"
+        },
+        "get_speed": {
+                "oper_type": "ipmi",
+                "template": "ipmitool raw 0x04 0x2d {}",
+                "command": [
+                        "0x81",
+                        "0x80",
+                        "0x83",
+                        "0x82",
+                        "0x85",
+                        "0x84",
+                        "0x87",
+                        "0x86"
+                ],
+                "formula": "int('{}'.split()[0],16)*150",
+                "max_front": 23000,
+                "max_rear": 20500
+        },
+        "get_target_speed": {
+                "oper_type": "fixed",
+                "value": "N/A"
+        },
+        "get_speed_tolerance": {
+                "oper_type": "fixed",
+                "value": 10
+        },
+        "set_speed": {
+                "oper_type": "ipmi",
+                "template": "ipmitool 0x04 {}",
+                "command": [
+                        "0x5 0x2 {}",
+                        "0x6 0x2 {}",
+                        "0x6 0x6 {}",
+                        "0x6 0x5 {}"
+                ],
+                "formula": "{}/100*255"
+        },
+        "get_status_led": {
+                "oper_type": "ipmi",
+                "template": "ipmitool 0x04 {}",
+                "command": [
+                        "0x5 0x2",
+                        "0x6 0x2",
+                        "0x6 0x6",
+                        "0x6 0x5"
+                ],
+                "formula": "'red' if {} == '0x00' else 'green'"
+        }
+}

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/fan.json
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/fan.json
@@ -16,7 +16,7 @@
         },
         "get_presence": {
                 "oper_type": "ipmi",
-                "template": "ipmitool raw 0x3a 0x03 0x03 {}",
+                "command_template": "ipmitool raw 0x3a 0x03 0x03 {}",
                 "command": [
                         "0x00",
                         "0x00",
@@ -31,7 +31,7 @@
         },
         "get_model": {
                 "oper_type": "ipmi",
-                "template": "ipmitool fru list {} | grep 'Board Part Number'",
+                "command_template": "ipmitool fru list {} | grep 'Board Part Number'",
                 "command": [
                         "5",
                         "5",
@@ -46,7 +46,7 @@
         },
         "get_serial": {
                 "oper_type": "ipmi",
-                "template": "ipmitool fru list {} | grep 'Board Serial'",
+                "command_template": "ipmitool fru list {} | grep 'Board Serial'",
                 "command": [
                         "5",
                         "5",
@@ -62,7 +62,7 @@
         "get_status": {},
         "get_direction": {
                 "oper_type": "ipmi",
-                "template": "ipmitool fru list {} | grep 'F2B\\|B2F'",
+                "command_template": "ipmitool fru list {} | grep 'F2B\\|B2F'",
                 "command": [
                         "5",
                         "5",
@@ -77,7 +77,7 @@
         },
         "get_speed": {
                 "oper_type": "ipmi",
-                "template": "ipmitool raw 0x04 0x2d {}",
+                "command_template": "ipmitool raw 0x04 0x2d {}",
                 "command": [
                         "0x81",
                         "0x80",
@@ -102,24 +102,57 @@
         },
         "set_speed": {
                 "oper_type": "ipmi",
-                "template": "ipmitool 0x04 {}",
+                "input_transform": "hex(int({} * 255 / 100.0))",
+                "command_template": "ipmitool raw 0x3a 0x0c 0x00 0x03 {}",
                 "command": [
-                        "0x5 0x2 {}",
-                        "0x6 0x2 {}",
-                        "0x6 0x6 {}",
-                        "0x6 0x5 {}"
+                        "0x40 {}",
+                        "0x40 {}",
+                        "0x44 {}",
+                        "0x44 {}",
+                        "0x4c {}",
+                        "0x4c {}",
+                        "0x50 {}",
+                        "0x50 {}"
+                ]
+        },
+        "set_status_led": {
+                "oper_type": "ipmi",
+                "avaliable_input": [
+                        "off",
+                        "amber",
+                        "green"
                 ],
-                "formula": "{}/100*255"
+                "input_transform": "'0x1' if '{0}' == 'amber' else '0x2' if '{0}' == 'green' else '0x0'",
+                "command_template": "ipmitool raw 0x3a 0x0a {}",
+                "command": [
+                        "0x4 {}",
+                        "0x4 {}",
+                        "0x5 {}",
+                        "0x5 {}",
+                        "0x6 {}",
+                        "0x6 {}",
+                        "0x7 {}",
+                        "0x7 {}"
+                ]
         },
         "get_status_led": {
                 "oper_type": "ipmi",
-                "template": "ipmitool 0x04 {}",
+                "command_template": "ipmitool raw 0x3a 0x0b {}",
                 "command": [
-                        "0x5 0x2",
-                        "0x6 0x2",
-                        "0x6 0x6",
-                        "0x6 0x5"
+                        "0x4",
+                        "0x4",
+                        "0x5",
+                        "0x5",
+                        "0x6",
+                        "0x6",
+                        "0x7",
+                        "0x7"
                 ],
-                "formula": "'red' if {} == '0x00' else 'green'"
+                "output_transform": {
+                        "00": "off",
+                        "01": "amber",
+                        "02": "green"
+                },
+                "default_output": "off"
         }
 }

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/psu.json
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/psu.json
@@ -1,0 +1,43 @@
+{
+    "psu_num": 2,
+    "fan_per_psu_num": 1,
+    "get_name": {
+            "oper_type": "fixed_list",
+            "value": [
+                    {
+                        "psu_name":"PSU-R",
+                        "fan_name":[
+                            "PSU-R-Fan"
+                        ],
+                        "presence_bit":4
+                    },
+                    {
+                        "psu_name":"PSU-L",
+                        "fan_name":[
+                            "PSU-L-Fan"
+                        ],
+                        "presence_bit":5
+                    }
+            ]
+    },
+    "get_power": {
+        "oper_type": "ipmi",
+        "command_template": "ipmitool sdr | grep {}",
+        "command": [
+            "PSUR_POut",
+            "PSUL_POut"
+        ],
+        "formula": "float('{}'.split()[2])"
+    },
+    "get_presence": {
+            "oper_type": "ipmi",
+            "command_template": "ipmitool raw 0x3a 0x0c 0x00 0x2 0x60",
+            "command":["0","0"],
+            "output_formula": [
+                "True if bin(0x{})[2:][::-1][4]=='0' else False",
+                "True if bin(0x{})[2:][::-1][5]=='0' else False"
+            ],
+            "default_output": "off"
+            
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Implement the following requirement from JIRA CSC-335.
**- How I did it**
Implement API to get the PSU PowerOut, Static name, and Presence status.
**- How to verify it**
Use the below example script to get the output

Test Script:
```python
#!/usr/bin/env

import time
import json
import sys
from sonic_platform import platform

print "============================ NEW API REPORT =============================="

platform = platform.Platform()
chassis = platform.get_chassis()

print "\n=============================== TEST PSU API ================================\n"

num_psu = chassis.get_num_psus()
all_psu = chassis.get_all_psus()
print "num of psus:\t", num_psu
# print "all psu:\t", all_psu
for psu in all_psu:
    print ""
    print "Name:\t\t\t", psu.get_name()
    print "Present:\t\t", psu.get_presence()
    print "Power:\t\t\t", psu.get_power()
```

Output:
```console
root@sonic:/home/admin# python test_psu.py 
============================ NEW API REPORT ==============================

=============================== TEST PSU API ================================

num of psus:    2

Name:                   PSU-R
Present:                True
Power:                  100.0

Name:                   PSU-L
Present:                True
Power:                  110.0
```
IPMI output for reference:
```console
root@sonic:/home/admin# ipmitool sdr
...
Fan1_Status      | 0x00              | ok
Fan2_Status      | 0x00              | ok
Fan3_Status      | 0x00              | ok
Fan4_Status      | 0x00              | ok
PSUL_Status      | 0x00              | ok
PSUR_Status      | 0x00              | ok
PowerStatus      | 0x00              | ok
...
PSUL_VIn         | 220 Volts         | ok
PSUL_CIn         | 0.60 Amps         | ok
PSUL_PIn         | 130 Watts         | ok
PSUL_Temp1       | 26 degrees C      | ok
PSUL_Temp2       | 35 degrees C      | ok
PSUL_Fan         | 12100 RPM         | ok
PSUL_VOut        | 12 Volts          | ok
PSUL_COut        | 9 Amps            | ok
PSUL_POut        | 110 Watts         | ok
PSUR_VIn         | 220 Volts         | ok
PSUR_CIn         | 0.50 Amps         | ok
PSUR_PIn         | 110 Watts         | ok
PSUR_Temp1       | 27 degrees C      | ok
PSUR_Temp2       | 33 degrees C      | ok
PSUR_Fan         | 12200 RPM         | ok
PSUR_VOut        | 12 Volts          | ok
PSUR_COut        | 8.10 Amps         | ok
PSUR_POut        | 100 Watts         | ok
...
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Design the JSON for support PSU attr and new common function to process the output to support get_presence, implement get_power following the design from FAN func.
